### PR TITLE
Fixed the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ npm install --save ethjs
 const Eth = require('ethjs');
 const eth = new Eth(new Eth.HttpProvider('https://ropsten.infura.io'));
 
-eth.getBlockByNumber(45300, (err, block) => {
+eth.getBlockByNumber(45300, true, (err, block) => {
   // result null { ...block data... }
 });
 
 const etherValue = Eth.toWei(72, 'ether');
 
-// result <BN ...>
+// result <BN: 3e733628714200000>
 
 const tokenABI = [{
   "constant": true,


### PR DESCRIPTION
The example now throws "(node:62290) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: [ethjs-query] method 'getBlockByNumber' requires at least 2 input (format type Q|T), 1 provided. For more information visit: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber". This is because `eth_getblockbynumber` now needs two parameters.

## ethjs

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/ethjs/ethjs/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/ethjs/ethjs/blob/master/.github/CONTRIBUTING.md)
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/ethjs/ethjs/blob/master/LICENSE.md).
