### PR TITLE
added broken test and supporting .sol and .json

### DIFF
--- a/src/tests/SampleMath.json
+++ b/src/tests/SampleMath.json
@@ -1,0 +1,53 @@
+{
+  "contract_name": "SampleMath",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "a",
+          "type": "uint256"
+        },
+        {
+          "name": "b",
+          "type": "uint256"
+        }
+      ],
+      "name": "add",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "a",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "b",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "c",
+          "type": "uint256"
+        }
+      ],
+      "name": "addEvent",
+      "type": "event"
+    }
+  ],
+  "unlinked_binary": "0x6060604052341561000f57600080fd5b5b60f08061001e6000396000f300606060405263ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663771602f78114603c575b600080fd5b3415604657600080fd5b60526004356024356064565b60405190815260200160405180910390f35b600082820183811015607257fe5b7ff639bd6b84a8831cd07b2ac9f171ca968a1ab9f1140b20d178e56810de25b53084848360405180848152602001838152602001828152602001935050505060405180910390a18091505b50929150505600a165627a7a72305820eeb42301cb44b2916247db5cc6d520050c2fbf2ddbfa30c217d541ad70b841ca0029",
+  "networks": {},
+  "schema_version": "0.0.5",
+  "updated_at": 1505335234403
+}

--- a/src/tests/SampleMath.sol
+++ b/src/tests/SampleMath.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.11;
+contract SampleMath {
+    function add(uint256 a, uint256 b) constant returns (uint256) {
+        uint256 c = a + b;
+        assert(c >= a);
+        addEvent(a, b, c);
+        return c;
+    }
+
+    event addEvent(uint256 a, uint256 b, uint256 c);
+}

--- a/src/tests/abi-event.js
+++ b/src/tests/abi-event.js
@@ -1,0 +1,33 @@
+const assert = require('chai').assert;
+const TestRPC = require('ethereumjs-testrpc');
+const Web3 = require('web3');
+const provider = TestRPC.provider();
+const Eth = require('../index.js');
+const SampleMathContract = require('./SampleMath.json');
+
+// This test uses a very simple Solidity contract that can be found
+// in SampleMath.sol
+// It uses the abi from that contract which is in SampleMath.json
+// The asssumption is that ethjs will create the same kind of object
+// from the event as web3, but as the failing test demonstrates, it does not
+describe('eth.js', () => {
+  describe('abitest', () => {
+    it('should create event options from abi like web3', (done) => {
+      const eth = new Eth(provider);
+      const addr = '0x6e0E0e02377Bc1d90E8a7c21f12BA385C2C35f78';
+      const SampleMathContractInstance = eth.contract(SampleMathContract.abi).at(addr);
+      assert.equal(typeof SampleMathContractInstance.add, 'function');
+      assert.equal(typeof SampleMathContractInstance.addEvent, 'function');
+      const web3 = new Web3();
+      const SampleMathContractInstanceWeb3 = web3.eth.contract(SampleMathContract.abi).at(addr);
+      assert.equal(typeof SampleMathContractInstanceWeb3.add, 'function');
+      assert.equal(typeof SampleMathContractInstanceWeb3.addEvent, 'function');
+      /*
+      const addEventWeb3 = SampleMathContractInstanceWeb3.addEvent({ a: 5 }, { fromBlock: 0, toBlock: 'latest' });
+      const addEvent = SampleMathContractInstance.addEvent({ a: 5 }, { fromBlock: 0, toBlock: 'latest' });
+      assert.equal(addEvent.options, addEventWeb3.options);
+      */
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Kumavis suggested I submit a PR with a broken test. That was a little tricky, since your policy doesn't allow commits with broken tests, so you'll have to rem back in the code to get it to fail. I went ahead and checked in the Solidity file. The json abi was generated with Truffle. 