### PR TITLE
Remove duplicate "js-sha3" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "ethjs-filter": "0.1.5",
     "ethjs-provider-http": "0.1.6",
     "bn.js": "4.11.6",
-    "js-sha3": "0.5.5",
     "ethjs-query": "0.2.6",
     "number-to-bn": "1.7.0",
     "ethjs-abi": "0.2.0",


### PR DESCRIPTION
This PR simply removes the duplicate **js-sha3** entry from the `dependencies` portion of the project's *package.json*.